### PR TITLE
Implement TCP client handshake and telemetry transmission flow

### DIFF
--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -134,10 +134,12 @@
     <ClCompile Include="Client.cpp" />
     <ClCompile Include="CSVReader.cpp" />
     <ClCompile Include="PacketBuilder.cpp" />
+    <ClCompile Include="TCPClient.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CSVReader.h" />
     <ClInclude Include="PacketBuilder.h" />
+    <ClInclude Include="TCPClient.h" />
     <ClInclude Include="TelemetryRecord.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Client/Client.vcxproj.filters
+++ b/Client/Client.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="PacketBuilder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="TCPClient.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TelemetryRecord.h">
@@ -33,6 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="PacketBuilder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TCPClient.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Client/TCPClient.cpp
+++ b/Client/TCPClient.cpp
@@ -1,0 +1,64 @@
+#include "TCPClient.h"
+
+#include <stdexcept>
+#include <string>
+#include <WS2tcpip.h>
+
+TCPClient::TCPClient(const std::string& serverIP, int port,
+	const std::string& csvPath, int delayMs)
+	: _serverIP(serverIP),
+	  _port(port),
+	  _delayMs(delayMs),
+	  _reader(csvPath)
+{
+}
+
+void TCPClient::Connect()
+{
+	WSADATA wsaData;
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+		throw std::runtime_error("WSAStartup failed with error " + std::to_string(WSAGetLastError()));
+	}
+
+	_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (_sock == INVALID_SOCKET) {
+		const int error = WSAGetLastError();
+		WSACleanup();
+		throw std::runtime_error("socket failed with error " + std::to_string(error));
+	}
+
+	sockaddr_in serverAddr{};
+	serverAddr.sin_family = AF_INET;
+	serverAddr.sin_port = htons(static_cast<u_short>(_port));
+
+	if (InetPtonA(AF_INET, _serverIP.c_str(), &serverAddr.sin_addr) != 1) {
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+		WSACleanup();
+		throw std::runtime_error("Invalid server IP address: " + _serverIP);
+	}
+
+	if (connect(_sock, reinterpret_cast<sockaddr*>(&serverAddr), sizeof(serverAddr)) == SOCKET_ERROR) {
+		const int error = WSAGetLastError();
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+		WSACleanup();
+		throw std::runtime_error("connect failed with error " + std::to_string(error));
+	}
+}
+
+void TCPClient::Run()
+{
+	throw std::runtime_error("TCPClient::Run is not implemented yet");
+}
+
+void TCPClient::Disconnect()
+{
+	if (_sock != INVALID_SOCKET) {
+		shutdown(_sock, SD_SEND);
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+	}
+
+	WSACleanup();
+}

--- a/Client/TCPClient.cpp
+++ b/Client/TCPClient.cpp
@@ -1,5 +1,6 @@
 #include "TCPClient.h"
 
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <WS2tcpip.h>
@@ -45,6 +46,37 @@ void TCPClient::Connect()
 		WSACleanup();
 		throw std::runtime_error("connect failed with error " + std::to_string(error));
 	}
+
+	char idBuffer[32] = {};
+	const int recvResult = recv(_sock, idBuffer, sizeof(idBuffer) - 1, 0);
+	if (recvResult <= 0) {
+		const int error = recvResult == 0 ? 0 : WSAGetLastError();
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+		WSACleanup();
+		throw std::runtime_error("Failed to receive aircraft ID. Error " + std::to_string(error));
+	}
+
+	idBuffer[recvResult] = '\0';
+
+	try {
+		_aircraftId = std::stoi(idBuffer);
+	}
+	catch (const std::exception&) {
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+		WSACleanup();
+		throw std::runtime_error("Received invalid aircraft ID from server: " + std::string(idBuffer));
+	}
+
+	if (_aircraftId <= 0) {
+		closesocket(_sock);
+		_sock = INVALID_SOCKET;
+		WSACleanup();
+		throw std::runtime_error("Received non-positive aircraft ID from server: " + std::to_string(_aircraftId));
+	}
+
+	std::cout << "Connected to server as aircraft " << _aircraftId << std::endl;
 }
 
 void TCPClient::Run()

--- a/Client/TCPClient.cpp
+++ b/Client/TCPClient.cpp
@@ -81,7 +81,39 @@ void TCPClient::Connect()
 
 void TCPClient::Run()
 {
-	throw std::runtime_error("TCPClient::Run is not implemented yet");
+	if (_sock == INVALID_SOCKET) {
+		throw std::runtime_error("TCPClient::Run called before a successful connection");
+	}
+
+	if (_aircraftId <= 0) {
+		throw std::runtime_error("TCPClient::Run called without a valid aircraft ID");
+	}
+
+	if (!_reader.IsOpen()) {
+		throw std::runtime_error("Telemetry CSV file is not open");
+	}
+
+	TelemetryRecord record;
+	int sentCount = 0;
+
+	while (_reader.ReadNext(record)) {
+		const std::string packet = PacketBuilder::Build(_aircraftId, record);
+		const int sendResult = send(_sock, packet.c_str(), static_cast<int>(packet.size()), 0);
+
+		if (sendResult == SOCKET_ERROR) {
+			throw std::runtime_error("send failed with error " + std::to_string(WSAGetLastError()));
+		}
+
+		++sentCount;
+		std::cout << "Sent packet " << sentCount << " for aircraft " << _aircraftId << std::endl;
+
+		if (_delayMs > 0) {
+			Sleep(_delayMs);
+		}
+	}
+
+	std::cout << "Completed telemetry transmission for aircraft " << _aircraftId
+		<< " after " << sentCount << " packets" << std::endl;
 }
 
 void TCPClient::Disconnect()

--- a/Client/TCPClient.h
+++ b/Client/TCPClient.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <string>
+#include <WinSock2.h>
+#include "CSVReader.h"
+#include "PacketBuilder.h"
+
+/**
+ * @class TCPClient
+ * @brief Manages the TCP telemetry client lifecycle.
+ *
+ * This class owns the client socket, CSV reader, and packet builder used to
+ * stream telemetry records to the server.
+ */
+class TCPClient {
+public:
+	/**
+	 * @brief Constructs a TCP client with its connection and telemetry settings.
+	 * @param serverIP IPv4 address of the server.
+	 * @param port TCP port used by the server.
+	 * @param csvPath Path to the telemetry CSV file.
+	 * @param delayMs Delay between packet sends in milliseconds.
+	 */
+	TCPClient(const std::string& serverIP, int port,
+		const std::string& csvPath, int delayMs);
+
+	/**
+	 * @brief Initializes Winsock, creates the socket, and connects to the server.
+	 */
+	void Connect();
+
+	/**
+	 * @brief Runs the telemetry transmission loop.
+	 */
+	void Run();
+
+	/**
+	 * @brief Gracefully closes the client connection and releases socket resources.
+	 */
+	void Disconnect();
+
+private:
+	std::string		_serverIP;					/**< IPv4 address of the destination server. */
+	int				_port;						/**< TCP port used for the server connection. */
+	int				_delayMs;					/**< Inter-packet delay used to simulate streaming telemetry. */
+	int				_aircraftId = -1;			/**< Unique aircraft ID assigned by the server. */
+	SOCKET			_sock		= INVALID_SOCKET;	/**< Connected client socket. */
+	CSVReader		_reader;					/**< Reads telemetry records from the configured CSV file. */
+	PacketBuilder	_builder;					/**< Formats telemetry records into protocol packets. */
+};

--- a/Server/ClientHandler.cpp
+++ b/Server/ClientHandler.cpp
@@ -1,10 +1,11 @@
 #include "ClientHandler.h"
 #include <iostream>
 
-ClientHandler::ClientHandler(SOCKET clientSocket, const sockaddr_in& clientAddr, DataHandler* dataHandler)
+ClientHandler::ClientHandler(SOCKET clientSocket, const sockaddr_in& clientAddr, int aircraftId, DataHandler* dataHandler)
 {
 	_socket = clientSocket;
 	_clientAddr = clientAddr;
+	_aircraftId = aircraftId;
 	_dataHandler = dataHandler;
 }
 
@@ -50,17 +51,30 @@ void ClientHandler::Stop()
 
 void ClientHandler::Run()
 {
+	const std::string idMessage = std::to_string(_aircraftId);
+	if (send(_socket, idMessage.c_str(), static_cast<int>(idMessage.size()), 0) == SOCKET_ERROR) {
+		std::string msg = "Error sending aircraft ID " + std::to_string(_aircraftId)
+			+ ". Error: " + std::to_string(WSAGetLastError());
+		if (_dataHandler) _dataHandler->AddData(msg);
+		else std::cout << msg << std::endl;
+		_running = false;
+		return;
+	}
+
 	char buffer[1024];
 	while (_running) {
 		int recvResult = recv(_socket, buffer, sizeof(buffer) - 1, 0);
 		if (recvResult > 0) {
 			buffer[recvResult] = '\0';
-			std::string msg = "Received from " + std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port)) + " -> " + buffer;
+			std::string msg = "Received from aircraft " + std::to_string(_aircraftId) + " "
+				+ std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port))
+				+ " -> " + buffer;
 			if (_dataHandler) _dataHandler->AddData(msg);
 			else std::cout << msg << std::endl;
 		}
 		else if (recvResult == 0) {
-			std::string msg = "Client disconnected: " + std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port));
+			std::string msg = "Aircraft " + std::to_string(_aircraftId) + " disconnected: "
+				+ std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port));
 			if (_dataHandler) _dataHandler->AddData(msg);
 			else std::cout << msg << std::endl;
 			_running = false; // Client disconnected

--- a/Server/ClientHandler.h
+++ b/Server/ClientHandler.h
@@ -10,6 +10,7 @@ private:
 	DataHandler* _dataHandler;						// Pointer to data handler for logging received messages
 	SOCKET				_socket;					// Client socket for communication
 	sockaddr_in			_clientAddr;				// Client address information
+	int					_aircraftId;				// Unique aircraft ID assigned by the server
 	std::thread			_thread;					// Thread for handling client communication
 	std::atomic_bool	_running{ false };			// If client is running
 
@@ -33,8 +34,9 @@ public:
 	/// @brief Constructs a ClientHandler for a given client socket and address, and a pointer to the data handler for logging received messages.
 	/// @param clientSocket incoming client socket to handle communication with the client
 	/// @param clientAddr address information for the client, used for logging purposes
+	/// @param aircraftId unique aircraft ID assigned by the server for this connection
 	/// @param dataHandler data handler pointer for logging received messages
-	ClientHandler(SOCKET clientSocket, const sockaddr_in& clientAddr, DataHandler* dataHandler);	// Constructor
+	ClientHandler(SOCKET clientSocket, const sockaddr_in& clientAddr, int aircraftId, DataHandler* dataHandler);	// Constructor
 
 	/// @brief Destructor for ClientHandler. Stops the client handler thread and cleans up resources.
 	~ClientHandler();																				// Destructor
@@ -49,4 +51,3 @@ public:
 	/// @return True/False indicating if the client handler thread is running.
 	bool IsRunning();								// Check if the client handler is currently running
 };
-

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -7,6 +7,7 @@
 #include "DataHandler.h"
 #include <vector>
 #include <string>
+#include <atomic>
 
 using namespace std;
 
@@ -82,6 +83,7 @@ int main(int argc, char* argv[])
 
 	// Vector to store active client handlers
 	vector<unique_ptr<ClientHandler>> clients;
+	std::atomic_int nextAircraftId{ 1 };
 
 	while (true)
 	{
@@ -96,13 +98,16 @@ int main(int argc, char* argv[])
 			continue;
 		}
 
+		const int aircraftId = nextAircraftId.fetch_add(1);
+
 		// Log the accepted connection
 		// Write to file instead of screen.
-		string acceptMsg = "Accepted Connection from " + string(inet_ntoa(clientAddr.sin_addr)) + ":" + to_string(ntohs(clientAddr.sin_port));
+		string acceptMsg = "Accepted aircraft " + to_string(aircraftId) + " from "
+			+ string(inet_ntoa(clientAddr.sin_addr)) + ":" + to_string(ntohs(clientAddr.sin_port));
 		dataHandler.AddData(acceptMsg);
 
 		// Start a new client handler for the accepted connection
-		auto handler = make_unique<ClientHandler>(clientSocket, clientAddr, &dataHandler);
+		auto handler = make_unique<ClientHandler>(clientSocket, clientAddr, aircraftId, &dataHandler);
 		handler->Start();
 		clients.push_back(std::move(handler));
 	}
@@ -119,4 +124,3 @@ int main(int argc, char* argv[])
 	WSACleanup();
 	return 1;
 }
-


### PR DESCRIPTION
Changes included:
- adds the new `TCPClient` module to the client project
- implements `TCPClient` connection and disconnect lifecycle
- assigns unique aircraft IDs on the server for new client connections
- sends the assigned aircraft ID from the server to the client on connect
- receives, validates, and stores the assigned aircraft ID in `TCPClient`
- implements the client-side telemetry transmission loop in `TCPClient::Run()`
- reads telemetry records through `CSVReader`
- builds protocol packets through `PacketBuilder`
- sends packetized telemetry over TCP with the configured inter-packet delay