### PR TITLE
Finalize telemetry processing and per-flight server summaries

### DIFF
--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -1,71 +1,44 @@
 #include <iostream>
-#include "CSVReader.h"
-#include "TelemetryRecord.h"
+#include <stdexcept>
+#include <string>
 
-#include <windows.networking.sockets.h>
+#include "TCPClient.h"
 
+namespace {
+constexpr int DEFAULT_PORT = 54000;
+constexpr int DEFAULT_DELAY_MS = 1000;
+constexpr char DEFAULT_SERVER_IP[] = "127.0.0.1";
+constexpr char DEFAULT_CSV_PATH[] = "katl-kefd-B737-700.txt";
+}
 
-int main() {
+int main(int argc, char* argv[]) {
+	std::string serverIP = DEFAULT_SERVER_IP;
+	int port = DEFAULT_PORT;
+	std::string csvPath = DEFAULT_CSV_PATH;
+	int delayMs = DEFAULT_DELAY_MS;
 
-	WSADATA wsaData;
-
-    if ((WSAStartup(MAKEWORD(2, 2), &wsaData)) != 0) {
-        return -1;
-    }
-
-	SOCKET ClientSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (ClientSocket == INVALID_SOCKET) {
-        WSACleanup();
-        return -1;
+	if (argc > 1) {
+		serverIP = argv[1];
+	}
+	if (argc > 2) {
+		port = std::stoi(argv[2]);
+	}
+	if (argc > 3) {
+		csvPath = argv[3];
+	}
+	if (argc > 4) {
+		delayMs = std::stoi(argv[4]);
 	}
 
-    sockaddr_in serverAddr;
-	serverAddr.sin_family = AF_INET;
-	serverAddr.sin_port = htons(54000);
-    serverAddr.sin_addr.s_addr = inet_addr("127.0.0.1");
-
-    if (connect(ClientSocket, (sockaddr*)&serverAddr, sizeof(serverAddr)) == SOCKET_ERROR) {
-        closesocket(ClientSocket);
-        WSACleanup();
-        return -1;
+	try {
+		TCPClient client(serverIP, port, csvPath, delayMs);
+		client.Connect();
+		client.Run();
+		client.Disconnect();
+		return 0;
 	}
-
-    std::string testFile = "katl-kefd-B737-700.txt";
-
-    CSVReader reader(testFile);
-    TelemetryRecord record;
-
-    int count = 0;
-
-    // Read Next will skip the header automatically on the first pass
-    while (reader.ReadNext(record) && count < 10) {
-        std::cout << "Record " << (count + 1) << " -> "
-            << "Time: [" << record.timestamp << "], "
-            << "Fuel: [" << record.fuel_qty << "]" << std::endl;
-        count++;
-
-
-		// Send the record to the server
-		std::string message = "Time: [" + record.timestamp + "], Fuel: [" + std::to_string(record.fuel_qty) + "]";
-		int sendResult = send(ClientSocket, message.c_str(), message.size(), 0);
-
-        if (sendResult == SOCKET_ERROR) {
-            std::cout << "Error sending packet. Error: " << WSAGetLastError() << std::endl;
-        }
-		Sleep(1000); // Sleep for 1 second between sends to simulate real-time telemetry
-    }
-
-    if (count == 0) {
-        std::cout << "\nNo records read." << std::endl;
-    }
-    else {
-        std::cout << "\nFound 10 records." << std::endl;
-    }
-
-
-	shutdown(ClientSocket, 1); // Gracefully shutdown the connection
-    closesocket(ClientSocket);
-    WSACleanup();
-
-    return 0;
+	catch (const std::exception& ex) {
+		std::cerr << "Client error: " << ex.what() << std::endl;
+		return -1;
+	}
 }

--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -32,8 +32,14 @@ int main(int argc, char* argv[]) {
 
 	try {
 		TCPClient client(serverIP, port, csvPath, delayMs);
-		client.Connect();
-		client.Run();
+		try {
+			client.Connect();
+			client.Run();
+		}
+		catch (...) {
+			client.Disconnect();
+			throw;
+		}
 		client.Disconnect();
 		return 0;
 	}

--- a/Client/TCPClient.cpp
+++ b/Client/TCPClient.cpp
@@ -98,10 +98,19 @@ void TCPClient::Run()
 
 	while (_reader.ReadNext(record)) {
 		const std::string packet = PacketBuilder::Build(_aircraftId, record);
-		const int sendResult = send(_sock, packet.c_str(), static_cast<int>(packet.size()), 0);
+		int totalSent = 0;
+		while (totalSent < static_cast<int>(packet.size())) {
+			const int sendResult = send(
+				_sock,
+				packet.c_str() + totalSent,
+				static_cast<int>(packet.size()) - totalSent,
+				0);
 
-		if (sendResult == SOCKET_ERROR) {
-			throw std::runtime_error("send failed with error " + std::to_string(WSAGetLastError()));
+			if (sendResult == SOCKET_ERROR) {
+				throw std::runtime_error("send failed with error " + std::to_string(WSAGetLastError()));
+			}
+
+			totalSent += sendResult;
 		}
 
 		++sentCount;

--- a/Server/ClientHandler.cpp
+++ b/Server/ClientHandler.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <iomanip>
 #include <optional>
 
 namespace {
@@ -191,22 +192,41 @@ void ClientHandler::Run()
 
 				++_packetCount;
 				_lastTimestamp = parsedPacket->timestamp;
+
+				if (_hasPreviousSample) {
+					const double deltaFuel = _previousFuelQty - parsedPacket->fuelQty;
+					const double deltaSeconds = std::difftime(*parsedTimestamp, _previousTimestamp);
+					const double currentRate = (deltaSeconds > 0.0) ? deltaFuel / deltaSeconds : 0.0;
+
+					// Maintain the average online so the handler does not need to keep
+					// every instantaneous rate for the full duration of the flight.
+					++_averageSampleCount;
+					_runningAverage += (currentRate - _runningAverage) / static_cast<double>(_averageSampleCount);
+				}
+
 				_previousFuelQty = parsedPacket->fuelQty;
 				_previousTimestamp = *parsedTimestamp;
 				_hasPreviousSample = true;
 			}
 		}
 		else if (recvResult == 0) {
-			std::string msg = "Aircraft " + std::to_string(_aircraftId) + " disconnected: "
-				+ std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port));
-			if (_dataHandler) _dataHandler->AddData(msg);
-			else std::cout << msg << std::endl;
+			if (_packetCount > 0 && _dataHandler) {
+				std::ostringstream flightRecord;
+				flightRecord << _aircraftId << ','
+					<< std::fixed << std::setprecision(6) << _runningAverage << ','
+					<< _lastTimestamp << ','
+					<< _packetCount;
+				_dataHandler->AddData(flightRecord.str());
+			}
+
+			std::cout << "Aircraft " << _aircraftId << " disconnected after "
+				<< _packetCount << " packets. Final average fuel consumption: "
+				<< std::fixed << std::setprecision(6) << _runningAverage << " gal/s" << std::endl;
 			_running = false; // Client disconnected
 		}
 		else {
-			std::string msg = "Error receiving data. Error: " + std::to_string(WSAGetLastError());
-			if (_dataHandler) _dataHandler->AddData(msg);
-			else std::cout << msg << std::endl;
+			std::cerr << "Error receiving data from aircraft " << _aircraftId
+				<< ". Error: " << WSAGetLastError() << std::endl;
 			_running = false; // Error occurred
 		}
 	}
@@ -215,11 +235,4 @@ void ClientHandler::Run()
 bool ClientHandler::IsRunning()
 {
 	return _running;
-}
-
-double ClientHandler::CalculateFuelConsumption()
-{
-	_fuelConsumption = _previousFuelQty - _currentFuelQty;
-
-	return _fuelConsumption;
 }

--- a/Server/ClientHandler.cpp
+++ b/Server/ClientHandler.cpp
@@ -1,5 +1,89 @@
 #include "ClientHandler.h"
+
 #include <iostream>
+#include <sstream>
+#include <optional>
+
+namespace {
+struct ParsedTelemetryPacket {
+	int aircraftId = 0;
+	std::string timestamp;
+	double fuelQty = 0.0;
+};
+
+std::optional<std::time_t> ParseTimestamp(const std::string& timestamp)
+{
+	// Project telemetry files use a flexible D_M_YYYY HH:MM:SS shape, so parse
+	// the date/time components manually instead of relying on a fixed-width format.
+	const auto spacePos = timestamp.find(' ');
+	if (spacePos == std::string::npos) {
+		return std::nullopt;
+	}
+
+	const std::string datePart = timestamp.substr(0, spacePos);
+	const std::string timePart = timestamp.substr(spacePos + 1);
+
+	std::stringstream dateStream(datePart);
+	std::stringstream timeStream(timePart);
+	std::string dayStr;
+	std::string monthStr;
+	std::string yearStr;
+	std::string hourStr;
+	std::string minuteStr;
+	std::string secondStr;
+
+	if (!std::getline(dateStream, dayStr, '_') || !std::getline(dateStream, monthStr, '_') || !std::getline(dateStream, yearStr)) {
+		return std::nullopt;
+	}
+	if (!std::getline(timeStream, hourStr, ':') || !std::getline(timeStream, minuteStr, ':') || !std::getline(timeStream, secondStr)) {
+		return std::nullopt;
+	}
+
+	try {
+		std::tm tm{};
+		tm.tm_mday = std::stoi(dayStr);
+		tm.tm_mon = std::stoi(monthStr) - 1;
+		tm.tm_year = std::stoi(yearStr) - 1900;
+		tm.tm_hour = std::stoi(hourStr);
+		tm.tm_min = std::stoi(minuteStr);
+		tm.tm_sec = std::stoi(secondStr);
+		tm.tm_isdst = -1;
+
+		const std::time_t parsed = std::mktime(&tm);
+		if (parsed == -1) {
+			return std::nullopt;
+		}
+
+		return parsed;
+	}
+	catch (const std::exception&) {
+		return std::nullopt;
+	}
+}
+
+std::optional<ParsedTelemetryPacket> ParsePacket(const std::string& packet)
+{
+	std::stringstream ss(packet);
+	std::string idStr;
+	std::string timestampStr;
+	std::string fuelStr;
+
+	if (!std::getline(ss, idStr, '|') || !std::getline(ss, timestampStr, '|') || !std::getline(ss, fuelStr)) {
+		return std::nullopt;
+	}
+
+	try {
+		ParsedTelemetryPacket parsed;
+		parsed.aircraftId = std::stoi(idStr);
+		parsed.timestamp = timestampStr;
+		parsed.fuelQty = std::stod(fuelStr);
+		return parsed;
+	}
+	catch (const std::exception&) {
+		return std::nullopt;
+	}
+}
+}
 
 ClientHandler::ClientHandler(SOCKET clientSocket, const sockaddr_in& clientAddr, int aircraftId, DataHandler* dataHandler)
 {
@@ -62,15 +146,55 @@ void ClientHandler::Run()
 	}
 
 	char buffer[1024];
+	std::string recvBuffer;
 	while (_running) {
 		int recvResult = recv(_socket, buffer, sizeof(buffer) - 1, 0);
 		if (recvResult > 0) {
-			buffer[recvResult] = '\0';
-			std::string msg = "Received from aircraft " + std::to_string(_aircraftId) + " "
-				+ std::string(inet_ntoa(_clientAddr.sin_addr)) + ":" + std::to_string(ntohs(_clientAddr.sin_port))
-				+ " -> " + buffer;
-			if (_dataHandler) _dataHandler->AddData(msg);
-			else std::cout << msg << std::endl;
+			// TCP is a byte stream, so one recv() can contain partial packets or
+			// multiple newline-delimited packets. Accumulate until a full line exists.
+			recvBuffer.append(buffer, buffer + recvResult);
+
+			std::size_t newlinePos = std::string::npos;
+			while ((newlinePos = recvBuffer.find('\n')) != std::string::npos) {
+				std::string packet = recvBuffer.substr(0, newlinePos);
+				recvBuffer.erase(0, newlinePos + 1);
+
+				if (!packet.empty() && packet.back() == '\r') {
+					packet.pop_back();
+				}
+				if (packet.empty()) {
+					continue;
+				}
+
+				const auto parsedPacket = ParsePacket(packet);
+				if (!parsedPacket.has_value()) {
+					std::cerr << "Malformed packet from aircraft " << _aircraftId
+						<< ": " << packet << std::endl;
+					continue;
+				}
+				if (parsedPacket->aircraftId != _aircraftId) {
+					std::cerr << "Aircraft ID mismatch. Expected " << _aircraftId
+						<< " but received " << parsedPacket->aircraftId << std::endl;
+					continue;
+				}
+				if (parsedPacket->fuelQty < 0.0) {
+					std::cerr << "Negative fuel quantity from aircraft " << _aircraftId << std::endl;
+					continue;
+				}
+
+				const auto parsedTimestamp = ParseTimestamp(parsedPacket->timestamp);
+				if (!parsedTimestamp.has_value()) {
+					std::cerr << "Invalid timestamp from aircraft " << _aircraftId
+						<< ": " << parsedPacket->timestamp << std::endl;
+					continue;
+				}
+
+				++_packetCount;
+				_lastTimestamp = parsedPacket->timestamp;
+				_previousFuelQty = parsedPacket->fuelQty;
+				_previousTimestamp = *parsedTimestamp;
+				_hasPreviousSample = true;
+			}
 		}
 		else if (recvResult == 0) {
 			std::string msg = "Aircraft " + std::to_string(_aircraftId) + " disconnected: "

--- a/Server/ClientHandler.h
+++ b/Server/ClientHandler.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <windows.networking.sockets.h>
+#include <string>
 #include <thread>
 #include <atomic>
+#include <ctime>
 #include "DataHandler.h"
 
 class ClientHandler
@@ -14,18 +16,13 @@ private:
 	std::thread			_thread;					// Thread for handling client communication
 	std::atomic_bool	_running{ false };			// If client is running
 
-	int					_messageCount{ 0 };			// Count of messages received
-	double				_startFuelQty{ 0.0 };		// Starting fuel quantity 
-	double 				_previousFuelQty{ 0.0 };	// Total fuel consumed based on received data		
-	double				_currentFuelQty{ 0.0 };		// Current based on the latest received data
-	double				_finalFuelQty{ 0.0 };		// Final fuel quantity received
-
-	/// @brief The current fuel consumption.
-	double				_fuelConsumption{ 0.0 };	// The current fuel consumption
-
-	/// @brief Calculates the fuel consumption based on previous and current fuel quantities
-	/// @return The calculated fuel consumption
-	double	CalculateFuelConsumption();				// Calculate fuel consumption
+	int					_packetCount{ 0 };			// Count of parsed telemetry packets received
+	double 				_previousFuelQty{ 0.0 };	// Fuel quantity from the prior telemetry packet
+	std::time_t			_previousTimestamp{ 0 };	// Timestamp from the prior telemetry packet
+	bool				_hasPreviousSample{ false };	// Whether a prior telemetry sample is available
+	double				_runningAverage{ 0.0 };		// Running average fuel consumption in gallons per second
+	int					_averageSampleCount{ 0 };	// Number of instantaneous rates included in the running average
+	std::string			_lastTimestamp;				// Timestamp from the last valid packet
 
 	/// @brief Main working loop for client thread. Receives data from the client socket and processes telemetry data.
 	void	Run();									// Main loop

--- a/Server/DataHandler.cpp
+++ b/Server/DataHandler.cpp
@@ -2,8 +2,9 @@
 
 DataHandler::DataHandler(const std::string& filename)
 {
-	// Open the file
-	_file.open(filename, std::ios::app);
+	// Start each server run with a fresh CSV log so the results from the
+	// current execution are not mixed with stale output from prior runs.
+	_file.open(filename, std::ios::trunc);
 
 	// Check if the file was opened successfully
 	if (!_file.is_open()) 

--- a/Server/DataHandler.h
+++ b/Server/DataHandler.h
@@ -26,7 +26,7 @@ private:
 	void WriteData();							// Write data from queue to file
 
 public:
-	/// @brief Constructs a DataHandler and opens the specified file in append mode.
+	/// @brief Constructs a DataHandler and opens the specified file for a fresh server run.
 	/// @param filename Path to the log file.
 	DataHandler(const std::string& filename);	// Constructor
 

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -12,31 +12,16 @@
 using namespace std;
 
 const int DEFAULT_PORT = 54000;
-const char* DEFAULT_IP = { "127.0.0.1" };
-
 int main(int argc, char* argv[])
 {
 	int port = DEFAULT_PORT;
-	string ip = DEFAULT_IP;
-	// Parse command line arguments for port and IP
-	if (argc > 2) {
-
-		// Validate port number
+	if (argc > 1) {
 		if (atoi(argv[1]) <= 0 || atoi(argv[1]) > 65535) {
 			cout << "Invalid port number. Using default port: " << DEFAULT_PORT << endl;
 			port = DEFAULT_PORT;
 		}
 		else {
 			port = atoi(argv[1]);
-		}
-
-		// Validate IP address format (basic check)
-		if (inet_addr(argv[2]) == INADDR_NONE) {
-			cout << "Invalid IP address format. Using default IP: " << DEFAULT_IP << endl;
-			ip = DEFAULT_IP;
-		}
-		else {
-			ip = argv[2];
 		}
 	}
 
@@ -100,11 +85,8 @@ int main(int argc, char* argv[])
 
 		const int aircraftId = nextAircraftId.fetch_add(1);
 
-		// Log the accepted connection
-		// Write to file instead of screen.
-		string acceptMsg = "Accepted aircraft " + to_string(aircraftId) + " from "
-			+ string(inet_ntoa(clientAddr.sin_addr)) + ":" + to_string(ntohs(clientAddr.sin_port));
-		dataHandler.AddData(acceptMsg);
+		cout << "Accepted aircraft " << aircraftId << " from "
+			<< inet_ntoa(clientAddr.sin_addr) << ":" << ntohs(clientAddr.sin_port) << endl;
 
 		// Start a new client handler for the accepted connection
 		auto handler = make_unique<ClientHandler>(clientSocket, clientAddr, aircraftId, &dataHandler);

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <atomic>
+#include <filesystem>
 
 using namespace std;
 
@@ -63,8 +64,14 @@ int main(int argc, char* argv[])
 	cout << "Server listening on port " << port << endl;
 
 	// Start the data handler
-	DataHandler dataHandler("server_data.log");
+	const std::string logPath = "flight_log.csv";
+	const bool shouldWriteHeader = !std::filesystem::exists(logPath)
+		|| std::filesystem::file_size(logPath) == 0;
+	DataHandler dataHandler(logPath);
 	dataHandler.Start();
+	if (shouldWriteHeader) {
+		dataHandler.AddData("aircraft_id,final_avg_gal_per_sec,flight_end_time,total_packets");
+	}
 
 	// Vector to store active client handlers
 	vector<unique_ptr<ClientHandler>> clients;

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -65,13 +65,9 @@ int main(int argc, char* argv[])
 
 	// Start the data handler
 	const std::string logPath = "flight_log.csv";
-	const bool shouldWriteHeader = !std::filesystem::exists(logPath)
-		|| std::filesystem::file_size(logPath) == 0;
 	DataHandler dataHandler(logPath);
 	dataHandler.Start();
-	if (shouldWriteHeader) {
-		dataHandler.AddData("aircraft_id,final_avg_gal_per_sec,flight_end_time,total_packets");
-	}
+	dataHandler.AddData("aircraft_id,final_avg_gal_per_sec,flight_end_time,total_packets");
 
 	// Vector to store active client handlers
 	vector<unique_ptr<ClientHandler>> clients;


### PR DESCRIPTION
## Summary

This PR completes the main end-to-end telemetry flow on top of the earlier TCP client/server handshake work.

Included changes:
- routes the client executable through `TCPClient`
- adds CLI-driven client configuration for server IP, port, CSV path, and send delay
- hardens client transmission by handling partial TCP sends and clean disconnect paths
- adds server-side parsing for telemetry packets in the `[ID]|[timestamp]|[fuel]` format
- parses telemetry timestamps from the project data format
- computes running fuel-consumption averages on the server
- emits a final per-flight summary when the client disconnects cleanly
- writes final flight summaries to `flight_log.csv` with a CSV header
- simplifies server startup argument handling and moves accepted-connection logs to stdout

## Verification

Manual end-to-end validation performed:
- started `Server.exe` on port `54000`
- ran `Client.exe 127.0.0.1 54000 <telemetry-file> 0`
- client connected successfully and transmitted all telemetry packets
- server accepted the connection, parsed the incoming packets, and logged disconnect summary
- `flight_log.csv` contained a final record in the expected CSV shape

Example output row:
```csv
aircraft_id,final_avg_gal_per_sec,flight_end_time,total_packets
1,0.220933,3_3_2023 17:48:29,8564
